### PR TITLE
Added missing remove column Delete icon & Prevent users from deleting all columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A lightweight, mobile-friendly Kanban board application for managing tasks and p
 ### 📊 Column Management
 - Add new columns for custom workflows
 - Edit column names inline
-- Remove columns with confirmation
+- Remove columns with confirmation (fixing)
 - Drag tasks between columns
 
 ### 🎨 Theme Support

--- a/server.js
+++ b/server.js
@@ -1209,17 +1209,26 @@ const html = `<!DOCTYPE html>
         <main>
             <div class="board">
                 <div class="column" data-column="todo">
-                    <h2 contenteditable="true" class="column-name">To Do</h2>
+                    <div class="column-header">
+                        <h2 contenteditable="true" class="column-name">To Do</h2>
+                        <button class="remove-column" onclick="openDeleteColumnModal('todo')" title="Remove column">×</button>
+                    </div>
                     <div class="tasks" id="todo"></div>
                     <button class="add-task" data-column="todo">+ Add Task</button>
                 </div>
                 <div class="column" data-column="doing">
-                    <h2 contenteditable="true" class="column-name">Doing</h2>
+                    <div class="column-header">
+                        <h2 contenteditable="true" class="column-name">Doing</h2>
+                        <button class="remove-column" onclick="openDeleteColumnModal('doing')" title="Remove column">×</button>
+                    </div>
                     <div class="tasks" id="doing"></div>
                     <button class="add-task" data-column="doing">+ Add Task</button>
                 </div>
                 <div class="column" data-column="done">
-                    <h2 contenteditable="true" class="column-name">Done</h2>
+                    <div class="column-header">
+                        <h2 contenteditable="true" class="column-name">Done</h2>
+                        <button class="remove-column" onclick="openDeleteColumnModal('done')" title="Remove column">×</button>
+                    </div>
                     <div class="tasks" id="done"></div>
                     <button class="add-task" data-column="done">+ Add Task</button>
                 </div>
@@ -2242,11 +2251,26 @@ const html = `<!DOCTYPE html>
             column.className = 'column';
             column.dataset.column = columnId;
 
-            // Create elements individually
+            // Create column header container
+            const headerDiv = document.createElement('div');
+            headerDiv.className = 'column-header';
+
+            // Create column name
             const h2 = document.createElement('h2');
             h2.className = 'column-name';
             h2.contentEditable = true;
             h2.textContent = columnName;
+
+            // Create remove column button
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'remove-column';
+            removeBtn.innerHTML = '×';
+            removeBtn.title = 'Remove column';
+            removeBtn.onclick = () => openDeleteColumnModal(columnId);
+
+            // Append header elements
+            headerDiv.appendChild(h2);
+            headerDiv.appendChild(removeBtn);
 
             const tasksDiv = document.createElement('div');
             tasksDiv.className = 'tasks';
@@ -2258,7 +2282,7 @@ const html = `<!DOCTYPE html>
             addButton.textContent = '+ Add Task';
 
             // Append elements
-            column.appendChild(h2);
+            column.appendChild(headerDiv);
             column.appendChild(tasksDiv);
             column.appendChild(addButton);
 
@@ -2336,6 +2360,14 @@ const html = `<!DOCTYPE html>
 
         function confirmDeleteColumn() {
             if (columnToDelete) {
+                // Don't allow deleting all columns
+                const columnCount = Object.keys(boardData.boards[currentBoard].columns).length;
+                if (columnCount <= 1) {
+                    showToast('Cannot delete the last column');
+                    closeDeleteColumnModal();
+                    return;
+                }
+
                 delete boardData.boards[currentBoard].columns[columnToDelete];
                 saveTasks();
                 renderTasks();


### PR DESCRIPTION
## What?
- Adds the missing "Remove Column" icon to custom columns in the kanban board.
- Prevents users from deleting the last remaining column (always at least one column must exist).
- UI feedback for deletion attempts on the final column.
- Follows existing CSS for delete

## Why?
There was no way to delete custom columns before. This makes kanban organization easier and fixes UX issues with accidental column overload.
![image](https://github.com/user-attachments/assets/b8947efd-8787-49b5-aeaf-428ea733bbf4)

## Testing
- Added/removed columns.
- Tried deleting all columns (last one is protected).
- Confirmed no errors in UI/console.
![image](https://github.com/user-attachments/assets/1bbc285b-d243-4cc9-9c76-b2b46668c85f)
